### PR TITLE
[FIX] fix add connection params

### DIFF
--- a/src/linxo-connect/dto/widget-session.args.ts
+++ b/src/linxo-connect/dto/widget-session.args.ts
@@ -12,4 +12,5 @@ export interface WidgetSessionUrlArgs {
   font?: string;
   font_color?: string;
   elements_color?: string;
+  select_accounts?: boolean;
 }

--- a/src/linxo-connect/services/linxo-link.service.spec.ts
+++ b/src/linxo-connect/services/linxo-link.service.spec.ts
@@ -68,6 +68,7 @@ describe(LinxoConnectLinkService.name, () => {
       font: 'Arial',
       font_color: 'Blue',
       elements_color: 'Yellow',
+      select_accounts: true,
     };
 
     const widgetConfig: WidgetConfig = {

--- a/src/linxo-connect/services/linxo-link.service.ts
+++ b/src/linxo-connect/services/linxo-link.service.ts
@@ -53,6 +53,7 @@ export class LinxoConnectLinkService {
       font: widgetConfig?.iframe?.font,
       font_color: widgetConfig?.iframe?.fontColor,
       elements_color: widgetConfig?.iframe?.elementsColor,
+      select_accounts: true,
     };
 
     // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
## Description 
- Add select_account param to the generated add connection url. This will display the list of accounts to synchronise or not to the user.