### PR TITLE
[FIX] Remove wrong get User

### DIFF
--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -131,7 +131,6 @@ describe('HookService', () => {
     let updateCustomerSpy: jest.SpyInstance;
     let getIframeUrlSpy: jest.SpyInstance;
     let getCustomerByIdSpy: jest.SpyInstance;
-    let getUserSpy: jest.SpyInstance;
     let createNewUserSpy: jest.SpyInstance;
 
     const expectedWidgetConfig = {
@@ -153,7 +152,6 @@ describe('HookService', () => {
       getUserTokenSpy = jest
         .spyOn(linxoConnectAuthService, 'getUserToken')
         .mockResolvedValue(`user-token-${process.pid}`);
-      getUserSpy = jest.spyOn(linxoConnectUserService, 'getUser').mockResolvedValue(linxoConnectUserMock);
       createNewUserSpy = jest.spyOn(linxoConnectUserService, 'createNewUser').mockResolvedValue(`id-${process.pid}`);
       getIframeUrlSpy = jest.spyOn(linxoConnectLinkService, 'getIframeUrl').mockResolvedValue('MY_LINK_URL');
     });
@@ -186,9 +184,6 @@ describe('HookService', () => {
       // get algoan customer
       expect(algoanAuthenticateSpy).toHaveBeenCalled();
       expect(getCustomerByIdSpy).toHaveBeenCalledWith(aggregatorLinkRequiredMock.customerId);
-
-      // Should not to get the existing user
-      expect(getUserSpy).not.toHaveBeenCalled();
 
       // get a linxo connect client token
       expect(geClientTokenSpy).toHaveBeenCalledWith(
@@ -258,7 +253,6 @@ describe('HookService', () => {
         algoanCustomerService.getDefaultPassword(customerMock.id),
         Env.sandbox,
       );
-      expect(getUserSpy).toHaveBeenCalledWith(`user-token-${process.pid}`, `id-${process.pid}`, Env.sandbox);
 
       // DO NOT get a linxo connect client token
       expect(geClientTokenSpy).not.toHaveBeenCalled();
@@ -320,8 +314,6 @@ describe('HookService', () => {
         algoanCustomerService.getDefaultPassword(customerMock.id),
         Env.sandbox,
       );
-      expect(getUserSpy).not.toHaveBeenCalled();
-
       // BUT there is an error
 
       // SO Connect to linxo connect as client

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -86,7 +86,6 @@ export class HooksService {
           this.algoanCustomerService.getDefaultPassword(customer.id),
           env,
         );
-        await this.linxoConnectUserService.getUser(userAccessToken, linxoConnectUserId, env);
       } catch (e) {
         // the user doesn't exist anymore
         userAccessToken = undefined;


### PR DESCRIPTION
## Description 
The route GET /users/id is made to provide the information of a user (ref: [Linxo doc](https://developers.linxoconnect.com/reference-accounts-api#tag/manage-users/operation/getUser)) 
We can't call it until the user has accepted the linxo terms and conditions. Otherwise we get this error 
```
{
	"error": "UNAUTHORIZED",
	"error_description": "ACCEPT_TERMS_AND_CONDITIONS_REQUIRED",
	"id": "userid"
}
```
Besides, we did this call to check the existence of this user but the previous call to getUserToken is sufficient for this check